### PR TITLE
Make Error.stack writable

### DIFF
--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -691,7 +691,7 @@ void Interpreter::addStackTraceIfNecessary(CallFrame* callFrame, JSValue error)
             builder.append('\n');
     }
 
-    errorObject->putDirect(*vm, vm->propertyNames->stack, jsString(vm, builder.toString()), ReadOnly | DontDelete);
+    errorObject->putDirect(*vm, vm->propertyNames->stack, jsString(vm, builder.toString()), DontDelete);
 }
 
 NEVER_INLINE HandlerInfo* Interpreter::throwException(CallFrame*& callFrame, JSValue& exceptionValue, unsigned bytecodeOffset)


### PR DESCRIPTION
Solve Promise stack rewriting for frameworks such as `bluebird` and `q`

https://github.com/ariya/phantomjs/issues/12381
https://github.com/petkaantonov/bluebird/issues/942
https://github.com/kriskowal/q/issues/579