### PR TITLE
Allow setting devicePixelRatio

### DIFF
--- a/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.cpp
+++ b/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.cpp
@@ -1385,6 +1385,11 @@ void QWebPageAdapter::setDevicePixelRatio(float devicePixelRatio)
     page->setDeviceScaleFactor(devicePixelRatio);
 }
 
+float QWebPageAdapter::devicePixelRatio()
+{
+    return page->deviceScaleFactor();
+}
+
 bool QWebPageAdapter::handleKeyEvent(QKeyEvent *ev)
 {
     Frame* frame = page->focusController()->focusedOrMainFrame();

--- a/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.h
+++ b/Source/WebKit/qt/WebCoreSupport/QWebPageAdapter.h
@@ -358,6 +358,7 @@ public:
 
     ViewportAttributes viewportAttributesForSize(const QSize& availableSize, const QSize& deviceSize) const;
     void setDevicePixelRatio(float devicePixelRatio);
+    float devicePixelRatio();
 
     QWebSettings *settings;
 

--- a/Source/WebKit/qt/WidgetApi/qwebpage.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebpage.cpp
@@ -196,6 +196,7 @@ QWebPagePrivate::QWebPagePrivate(QWebPage *qq)
 #endif
     , linkPolicy(QWebPage::DontDelegateLinks)
     , m_viewportSize(QSize(0, 0))
+    , m_devicePixelRatio(qreal(0))
     , useFixedLayout(false)
     , window(0)
     , inspectorFrontend(0)
@@ -2044,6 +2045,16 @@ void QWebPagePrivate::_q_updateScreen(QScreen* screen)
 {
     if (screen)
         setDevicePixelRatio(screen->devicePixelRatio());
+}
+
+void QWebPage::setDevicePixelRatio(qreal ratio)
+{
+    d->setDevicePixelRatio(ratio);
+}
+
+qreal QWebPage::devicePixelRatio() const
+{
+    return d->devicePixelRatio();
 }
 
 static int getintenv(const char* variable)

--- a/Source/WebKit/qt/WidgetApi/qwebpage.h
+++ b/Source/WebKit/qt/WidgetApi/qwebpage.h
@@ -305,6 +305,8 @@ public:
     virtual void triggerAction(WebAction action, bool checked = false);
 
     QSize viewportSize() const;
+    void setDevicePixelRatio(qreal ratio);
+    qreal devicePixelRatio() const;
     void setViewportSize(const QSize &size) const;
     ViewportAttributes viewportAttributesForSize(const QSize& availableSize) const;
 

--- a/Source/WebKit/qt/WidgetApi/qwebpage_p.h
+++ b/Source/WebKit/qt/WidgetApi/qwebpage_p.h
@@ -190,6 +190,7 @@ public:
     QWebPage::LinkDelegationPolicy linkPolicy;
 
     QSize m_viewportSize;
+    qreal m_devicePixelRatio;
     QSize fixedLayoutSize;
 
     QWebHitTestResult hitTestResult;


### PR DESCRIPTION
Attempting to revive https://github.com/ariya/phantomjs/pull/12839 upstream, this should allow [webpage.ccp](https://github.com/ariya/phantomjs/pull/12839/files#diff-e6d43d0460770360ad54e3b50f04734cR1283) next to make use of this and actually set and overwrite the pixelratio.

Refer to https://github.com/ariya/phantomjs/issues/10964 for the what and why.
