### PR TITLE
Prevent leaks when loadImages=no Take 2

### DIFF
--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -61,7 +61,7 @@ public:
     void setLoadManually(bool loadManually) { m_loadManually = loadManually; }
 
     bool hasPendingBeforeLoadEvent() const { return m_hasPendingBeforeLoadEvent; }
-    bool hasPendingActivity() const { return m_hasPendingLoadEvent || m_hasPendingErrorEvent; }
+    bool hasPendingActivity() const { return (m_hasPendingLoadEvent && !m_postponeLoadImage) || m_hasPendingErrorEvent; }
 
     void dispatchPendingEvent(ImageEventSender*);
 
@@ -94,6 +94,7 @@ private:
     CachedResourceHandle<CachedImage> m_image;
     Timer<ImageLoader> m_derefElementTimer;
     AtomicString m_failedLoadURL;
+    bool m_postponeLoadImage : 1;
     bool m_hasPendingBeforeLoadEvent : 1;
     bool m_hasPendingLoadEvent : 1;
     bool m_hasPendingErrorEvent : 1;


### PR DESCRIPTION
This is a different approach to fixing the leaks. The previous way triggered some regression tests when adapted to current WebKit. This way fixes the leaks and passes the regression tests. 

https://bugs.webkit.org/show_bug.cgi?id=154452
https://bugs.webkit.org/attachment.cgi?id=272033&action=diff

https://github.com/ariya/phantomjs/issues/12903