### PR TITLE
Repeat <thead> and <tfoot> when splitting table across pages

### DIFF
--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -662,7 +662,59 @@ void RenderTable::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
             child->paint(info, childPoint);
         }
     }
-    
+
+    bool repaintedHead = false;
+    IntPoint repaintedHeadPoint;
+    bool repaintedFoot = false;
+    IntPoint repaintedFootPoint;
+    if (view()->pageLogicalHeight()) {
+        // re-paint header/footer if table is split over multiple pages
+        if (m_head) {
+            LayoutPoint childPoint = flipForWritingModeForChild(m_head, paintOffset);
+            if (!info.rect.contains(childPoint.x() + m_head->x(), childPoint.y() + m_head->y())) {
+                repaintedHeadPoint = IntPoint(childPoint.x(), info.rect.y() - m_head->y());
+                repaintedHead = true;
+                dynamic_cast<RenderObject*>(m_head)->paint(info, repaintedHeadPoint);
+            }
+        }
+        if (m_foot) {
+            LayoutPoint childPoint = flipForWritingModeForChild(m_foot, paintOffset);
+            if (!info.rect.contains(childPoint.x() + m_foot->x(), childPoint.y() + m_foot->y())) {
+                // find actual end of table on current page
+                int dy = 0;
+                const int max_dy = info.rect.y() + info.rect.height();
+                const int vspace = vBorderSpacing();
+                for (RenderObject* section = firstChild(); section; section = section->nextSibling()) {
+                    if (section->isTableSection()) {
+                        if (toRenderBox(section)->y() > max_dy) {
+                            continue;
+                        }
+                        int i = 0;
+                        for(RenderObject* row = section->firstChild(); row; row = row->nextSibling()) {
+                            if (!row->isTableRow()) {
+                                continue;
+                            }
+                            // get actual bottom-y position of this row - pretty complicated, how could this be simplified?
+                            // note how we have to take the rowPoint and section's y-offset into account, see e.g.
+                            // RenderTableSection::paint where this is also done...
+                            LayoutPoint rowPoint = flipForWritingModeForChild(toRenderBox(row), paintOffset);
+                            int row_dy = rowPoint.y() + toRenderBox(row)->y() + toRenderBox(row)->logicalHeight() + toRenderBox(section)->y();
+                            if (row_dy < max_dy && row_dy > dy) {
+                                dy = row_dy;
+                            } else if (row_dy > max_dy) {
+                                break;
+                            }
+                            i++;
+                        }
+                    }
+                }
+                repaintedFoot = true;
+                repaintedFootPoint = IntPoint(childPoint.x(), dy - m_foot->y());
+                dynamic_cast<RenderObject*>(m_foot)->paint(info, repaintedFootPoint);
+            }
+        }
+    }
+
     if (collapseBorders() && paintPhase == PaintPhaseChildBlockBackground && style()->visibility() == VISIBLE) {
         recalcCollapsedBorders();
         // Using our cached sorted styles, we then do individual passes,
@@ -673,6 +725,12 @@ void RenderTable::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
             m_currentBorder = &m_collapsedBorders[i];
             for (RenderTableSection* section = bottomSection(); section; section = sectionAbove(section)) {
                 LayoutPoint childPoint = flipForWritingModeForChild(section, paintOffset);
+                // also repaint borders of header/footer if required
+                if (section == m_head && repaintedHead) {
+                    childPoint = repaintedHeadPoint;
+                } else if (section == m_foot && repaintedFoot) {
+                    childPoint = repaintedFootPoint;
+                }
                 section->paint(info, childPoint);
             }
         }


### PR DESCRIPTION
This fix for ariya/phantomjs#13324 is an adaptation of ariya/phantomjs#13331 modified for the new submodule linking of QtWebKit used starting 2.1.0.

I am not the author of the original patch (@trigveaa is) nor am I competent enough with the QtWebKit codebase to fully endorse it. All I know is that this patch seems to fix the issue for my use-case (aside from the page header overlap I reported in ariya/phantomjs#13331).

Cheers