### PR TITLE
Add QPdfWriter support to QWebFrame

### DIFF
--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -838,22 +838,19 @@ void QWebFrame::print(QPdfWriter *pdfWriter, PrintCallback *callback) const
 
     if (!painter.begin(pdfWriter))
         return;
+
+    // calculate zoomFactors (see QWebFrame::print(QPrinter...))
+    const qreal zoomFactorX = (qreal)pdfWriter->logicalDpiX() / pdfWriter->resolution();
+    const qreal zoomFactorY = (qreal)pdfWriter->logicalDpiY() / pdfWriter->resolution();
     
     qreal pdfWriterResolution = pdfWriter->resolution();
-    QRect pageRect = pdfWriter->pageLayout().paintRectPixels(pdfWriterResolution);
+    QRect qpdfWriterRect = pdfWriter->pageLayout().paintRectPixels(pdfWriterResolution);
+    QRect pageRect(0, 0, int(qpdfWriterRect.width() / zoomFactorX), int(qpdfWriterRect.height() / zoomFactorY));
+
 
     QtPrintContext printContext(&painter, pageRect, d);
 
-    // TODO: add painter scaling and zoom support
-    // the normal print method scales the painter like so:
-
-    // painter.scale(zoomFactorX, zoomFactorY);
-
-    // but the current phantomJS (at this time, 2.1)
-    // doesn't support page.zoomFactor on PDFs anyway
-
     int lastPage = printContext.pageCount() - 1;
-    // indexing should start a 1 for header and footer page number logic
     for (int page = 0; page < printContext.pageCount(); page++) {
         if (headerFooter.isValid()) {
             // print header/footer

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -830,6 +830,55 @@ void QWebFrame::print(QPrinter *printer) const
     print(printer, 0);
 }
 
+void QWebFrame::print(QPdfWriter *pdfWriter, PrintCallback *callback) const
+{
+    QPainter painter;
+
+    HeaderFooter headerFooter(this, pdfWriter, callback);
+
+    if (!painter.begin(pdfWriter))
+        return;
+    
+    qreal pdfWriterResolution = pdfWriter->resolution();
+    QRect pageRect = pdfWriter->pageLayout().paintRectPixels(pdfWriterResolution);
+
+    QtPrintContext printContext(&painter, pageRect, d);
+
+    // TODO: add painter scaling and zoom support
+    // the normal print method scales the painter like so:
+
+    // painter.scale(zoomFactorX, zoomFactorY);
+
+    // but the current phantomJS (at this time, 2.1)
+    // doesn't support page.zoomFactor on PDFs anyway
+
+    int lastPage = printContext.pageCount() - 1;
+    // indexing should start a 1 for header and footer page number logic
+    for (int page = 0; page < printContext.pageCount(); page++) {
+        if (headerFooter.isValid()) {
+            // print header/footer
+
+            // QPdfWriter doesn't support collateCopies() or numCopies() 
+            // so there is no need to call d->frame->getPagination(...)
+            headerFooter.paintHeader(
+                printContext.graphicsContext(),
+                pageRect,
+                page + 1, // logical page is one more than the index
+                printContext.pageCount()
+            );
+            
+            headerFooter.paintFooter(
+                printContext.graphicsContext(),
+                pageRect,
+                page + 1,
+                printContext.pageCount()
+            );
+        }
+        printContext.spoolPage(page, pageRect.width());
+        if (page != lastPage) pdfWriter->newPage();
+    }
+}
+
 void QWebFrame::print(QPrinter *printer, PrintCallback *callback) const
 {
 #if HAVE(QTPRINTSUPPORT)

--- a/Source/WebKit/qt/WidgetApi/qwebframe.h
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.h
@@ -27,6 +27,7 @@
 #include <QtGui/qicon.h>
 #include <QtNetwork/qnetworkaccessmanager.h>
 #include <QtWebKit/qwebkitglobal.h>
+#include <QPdfWriter>
 
 QT_BEGIN_NAMESPACE
 class QRect;
@@ -226,6 +227,7 @@ public Q_SLOTS:
     void print(QPrinter *printer) const;
     void print(QPrinter *printer, PrintCallback *callback) const;
 #endif
+    void print(QPdfWriter *pdfWriter, PrintCallback *callback) const;
 
 Q_SIGNALS:
     void javaScriptWindowObjectCleared();


### PR DESCRIPTION
This is to fix https://github.com/ariya/phantomjs/issues/14268. To fully resolve this issue, another simple change is required in the PhantomJS source. **Another pull request to fix the phantomjs source will be linked and some tests will be included in that pull as well.**

**Context:** commit https://github.com/ariya/phantomjs/commit/7d7e5f345b646ef18d23138781ae94197335b342 adds support for rendering PDF to a base64 encoded string but this commit breaks multi-paged documents and headers and footers because it does not use a `QtPrintContext`.

The current QtWebKit version (even 5.7) does not currently support printing to a `QPdfWriter` or `QPagedPaintDevice`. **This code simply adds support for using a PrintContext for QPdfWriter.** The added methods are logical clones of the print(...) methods that take in a `QPrinter` rather than a `QPdfWriter`.

This way, we can keep the `renderBase64('pdf')` support and still have multi-paged documents. Hopefully newer version of QtWebKit will add support for this.