### PR TITLE
add support for qpagedpaintdevice printing in qwebframe

### DIFF
--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -942,6 +942,7 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     QtPrintContext printContext(&painter, pageRect, d);
     int lastPage = printContext.pageCount() - 1;
     for (int page = 0; page < printContext.pageCount(); page++) {
+        printContext.spoolPage(page, pageRect.width());
         if (headerFooter.isValid()) {
 
             // QPagedPaintDevice doesn't support collateCopies() or numCopies() 
@@ -953,7 +954,6 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
             headerFooter.paintFooter(printContext.graphicsContext(), pageRect,
                 page + 1, printContext.pageCount() );
         }
-        printContext.spoolPage(page, pageRect.width());
         if (page != lastPage) pagedPaintDevice->newPage();
     }
 }

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -840,6 +840,10 @@ void QWebFrame::print(QPrinter *printer, PrintCallback *callback) const
     if (!painter.begin(printer))
         return;
 
+    // the logical DPI of the printer can vary between 72 and 96 px on unix and windows respectively
+    // however chrome and other browsers seem to print at 96 dpi no matter the system so scaling the
+    // painter by the logicalDpi/96 gives us a consistent size
+    // for issue https://github.com/ariya/phantomjs/issues/12685
     const qreal zoomFactorX = (qreal)printer->logicalDpiX() / 96.0;
     const qreal zoomFactorY = (qreal)printer->logicalDpiY() / 96.0;
 
@@ -937,7 +941,10 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     if (!painter.begin(pagedPaintDevice))
         return;
     
-    // just hard code it to 96
+    // the logical DPI of the printer can vary between 72 and 96 px on unix and windows respectively
+    // however chrome and other browsers seem to print at 96 dpi no matter the system so scaling the
+    // painter by the logicalDpi/96 gives us a consistent size
+    // for issue https://github.com/ariya/phantomjs/issues/12685
     const qreal zoomFactorX = (qreal)pagedPaintDevice->logicalDpiX() / 96.0;
     const qreal zoomFactorY = (qreal)pagedPaintDevice->logicalDpiY() / 96.0;
     

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -840,8 +840,8 @@ void QWebFrame::print(QPrinter *printer, PrintCallback *callback) const
     if (!painter.begin(printer))
         return;
 
-    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / printer->physicalDpiX();
-    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / printer->physicalDpiY();
+    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / 96.0;
+    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / 96.0;
 
     QRect qprinterRect = printer->pageRect();
 
@@ -937,8 +937,9 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     if (!painter.begin(pagedPaintDevice))
         return;
     
-    const qreal zoomFactorX = (qreal)pagedPaintDevice->logicalDpiX() / pagedPaintDevice->physicalDpiX();
-    const qreal zoomFactorY = (qreal)pagedPaintDevice->logicalDpiY() / pagedPaintDevice->physicalDpiY();
+    // just hard code it to 96
+    const qreal zoomFactorX = (qreal)pagedPaintDevice->logicalDpiX() / 96.0;
+    const qreal zoomFactorY = (qreal)pagedPaintDevice->logicalDpiY() / 96.0;
     
     // similar to qprinterRect from ::print(...)
     QRect unscaledRect = pagedPaintDevice->pageLayout().paintRectPixels(pagedPaintDevice->logicalDpiX());

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -840,8 +840,8 @@ void QWebFrame::print(QPrinter *printer, PrintCallback *callback) const
     if (!painter.begin(printer))
         return;
 
-    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / qt_defaultDpi();
-    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / qt_defaultDpi();
+    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / printer->physicalDpiX();
+    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / printer->physicalDpiY();
 
     QRect qprinterRect = printer->pageRect();
 
@@ -937,8 +937,8 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     if (!painter.begin(pagedPaintDevice))
         return;
     
-    const qreal zoomFactorX = (qreal)pagedPaintDevice->logicalDpiX() / qt_defaultDpi();
-    const qreal zoomFactorY = (qreal)pagedPaintDevice->logicalDpiY() / qt_defaultDpi();
+    const qreal zoomFactorX = (qreal)pagedPaintDevice->logicalDpiX() / pagedPaintDevice->physicalDpiX();
+    const qreal zoomFactorY = (qreal)pagedPaintDevice->logicalDpiY() / pagedPaintDevice->physicalDpiY();
     
     // similar to qprinterRect from ::print(...)
     QRect unscaledRect = pagedPaintDevice->pageLayout().paintRectPixels(pagedPaintDevice->logicalDpiX());

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -840,8 +840,8 @@ void QWebFrame::print(QPrinter *printer, PrintCallback *callback) const
     if (!painter.begin(printer))
         return;
 
-    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / printer->resolution();
-    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / printer->resolution();
+    const qreal zoomFactorX = (qreal)printer->logicalDpiX() / qt_defaultDpi();
+    const qreal zoomFactorY = (qreal)printer->logicalDpiY() / qt_defaultDpi();
 
     QRect qprinterRect = printer->pageRect();
 
@@ -937,9 +937,16 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     if (!painter.begin(pagedPaintDevice))
         return;
     
-    QRect pageRect = pagedPaintDevice->pageLayout().paintRectPixels(pagedPaintDevice->logicalDpiX());
+    const qreal zoomFactorX = (qreal)pagedPaintDevice->logicalDpiX() / qt_defaultDpi();
+    const qreal zoomFactorY = (qreal)pagedPaintDevice->logicalDpiY() / qt_defaultDpi();
+    
+    // similar to qprinterRect from ::print(...)
+    QRect unscaledRect = pagedPaintDevice->pageLayout().paintRectPixels(pagedPaintDevice->logicalDpiX());
+    QRect pageRect(0, 0, int(unscaledRect.width() / zoomFactorX), int(unscaledRect.height() / zoomFactorY));
 
     QtPrintContext printContext(&painter, pageRect, d);
+    painter.scale(zoomFactorX, zoomFactorY);
+    
     int lastPage = printContext.pageCount() - 1;
     for (int page = 0; page < printContext.pageCount(); page++) {
         if (headerFooter.isValid()) {

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -944,7 +944,7 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     for (int page = 0; page < printContext.pageCount(); page++) {
         if (headerFooter.isValid()) {
 
-            // QPdfWriter doesn't support collateCopies() or numCopies() 
+            // QPagedPaintDevice doesn't support collateCopies() or numCopies() 
             // so there is no need to call d->frame->getPagination(...)
             // print header/footer
             headerFooter.paintHeader(printContext.graphicsContext(), pageRect,
@@ -954,7 +954,7 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
                 page + 1, printContext.pageCount() );
         }
         printContext.spoolPage(page, pageRect.width());
-        if (page != lastPage) pdfWriter->newPage();
+        if (page != lastPage) pagedPaintDevice->newPage();
     }
 }
 

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -937,7 +937,7 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     if (!painter.begin(pagedPaintDevice))
         return;
     
-    QRect pageRect = pagedPaintDevice->paintRectPixels(pagedPaintDevice->logicalDpiX());
+    QRect pageRect = pagedPaintDevice->pageLayout().paintRectPixels(pagedPaintDevice->logicalDpiX());
 
     QtPrintContext printContext(&painter, pageRect, d);
     int lastPage = printContext.pageCount() - 1;

--- a/Source/WebKit/qt/WidgetApi/qwebframe.cpp
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.cpp
@@ -942,7 +942,6 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
     QtPrintContext printContext(&painter, pageRect, d);
     int lastPage = printContext.pageCount() - 1;
     for (int page = 0; page < printContext.pageCount(); page++) {
-        printContext.spoolPage(page, pageRect.width());
         if (headerFooter.isValid()) {
 
             // QPagedPaintDevice doesn't support collateCopies() or numCopies() 
@@ -954,6 +953,7 @@ void QWebFrame::renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *
             headerFooter.paintFooter(printContext.graphicsContext(), pageRect,
                 page + 1, printContext.pageCount() );
         }
+        printContext.spoolPage(page, pageRect.width());
         if (page != lastPage) pagedPaintDevice->newPage();
     }
 }

--- a/Source/WebKit/qt/WidgetApi/qwebframe.h
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.h
@@ -27,6 +27,7 @@
 #include <QtGui/qicon.h>
 #include <QtNetwork/qnetworkaccessmanager.h>
 #include <QtWebKit/qwebkitglobal.h>
+#include <QPagedPaintDevice>
 
 QT_BEGIN_NAMESPACE
 class QRect;

--- a/Source/WebKit/qt/WidgetApi/qwebframe.h
+++ b/Source/WebKit/qt/WidgetApi/qwebframe.h
@@ -226,6 +226,8 @@ public Q_SLOTS:
     void print(QPrinter *printer) const;
     void print(QPrinter *printer, PrintCallback *callback) const;
 #endif
+    void renderPaged(QPagedPaintDevice *pagedPaintDevice) const;
+    void renderPaged(QPagedPaintDevice *pagedPaintDevice, PrintCallback *callback) const; 
 
 Q_SIGNALS:
     void javaScriptWindowObjectCleared();


### PR DESCRIPTION
For issue: https://github.com/ariya/phantomjs/issues/14268

This patch adds some `renderPaged(...)` methods to `QWebFrame`. This is to allow phantom to render PDFs as base64 and still have working pages.

To get this working within the master, `WebPage::renderPdf(...)` of phantomJS needs to call `m_mainFrame->renderPaged(&pdfWriter, this);` instead of whatever it's doing now.

[It's a small change](https://github.com/ariya/phantomjs/blob/afad1602880b1eb3e8df3c85814afe1a23161943/src/webpage.cpp#L1292-L1294)

**Edit:** *Please* see my comment [here](https://github.com/ariya/phantomjs/issues/12685#issuecomment-238011039),