### PR TITLE
Discard 3072 bytes instead of 1024 bytes

### DIFF
--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -103,7 +103,6 @@ void ARC4RandomNumberGenerator::stir()
     // Discard early keystream, as per recommendations in:
     // As per the Network Operations Division, cryptographic requirements
     // published on wikileaks on March 2017.
-    
     for (int i = 0; i < 3072; i++)
         getByte();
     m_count = 1600000;

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -101,8 +101,10 @@ void ARC4RandomNumberGenerator::stir()
     addRandomData(randomness, length);
 
     // Discard early keystream, as per recommendations in:
-    // http://www.wisdom.weizmann.ac.il/~itsik/RC4/Papers/Rc4_ksa.ps
-    for (int i = 0; i < 256; i++)
+    // As per the Network Operations Division, cryptographic requirements
+    // published on wikileaks on March 2017.
+    
+    for (int i = 0; i < 3072; i++)
         getByte();
     m_count = 1600000;
 }


### PR DESCRIPTION
As per Cryptographic Requirements published on Wikileaks on March 2017.
We discard more bytes of the first keystream to reduce the possibility of non-random bytes.